### PR TITLE
Adding node OS selection into the default node pool.

### DIFF
--- a/internal/entity/lab.go
+++ b/internal/entity/lab.go
@@ -14,7 +14,7 @@ type TfvarDefaultNodePoolType struct {
 	MaxCount                  int    `json:"maxCount"`
 	VmSize                    string `json:"vmSize"`
 	OnlyCriticalAddonsEnabled bool   `json:"onlyCriticalAddonsEnabled"`
-	NodeOsSku                 string `json:"nodeOsSku"`
+	OsSku                     string `json:"osSku"`
 }
 
 type TfvarServiceMeshType struct {

--- a/internal/entity/lab.go
+++ b/internal/entity/lab.go
@@ -14,6 +14,7 @@ type TfvarDefaultNodePoolType struct {
 	MaxCount                  int    `json:"maxCount"`
 	VmSize                    string `json:"vmSize"`
 	OnlyCriticalAddonsEnabled bool   `json:"onlyCriticalAddonsEnabled"`
+	NodeOsSku                 string `json:"nodeOsSku"`
 }
 
 type TfvarServiceMeshType struct {

--- a/internal/service/lab.go
+++ b/internal/service/lab.go
@@ -176,7 +176,7 @@ func (l *labService) HelperDefaultLab() (entity.LabType, error) {
 		MaxCount:                  1,
 		VmSize:                    "Standard_D2_v5",
 		OnlyCriticalAddonsEnabled: false,
-		NodeOsSku:                 "Ubuntu",
+		OsSku:                     "Ubuntu",
 	}
 
 	var defaultServiceMesh = entity.TfvarServiceMeshType{

--- a/internal/service/lab.go
+++ b/internal/service/lab.go
@@ -176,6 +176,7 @@ func (l *labService) HelperDefaultLab() (entity.LabType, error) {
 		MaxCount:                  1,
 		VmSize:                    "Standard_D2_v5",
 		OnlyCriticalAddonsEnabled: false,
+		NodeOsSku:                 "Ubuntu",
 	}
 
 	var defaultServiceMesh = entity.TfvarServiceMeshType{

--- a/tf/kubernetes_main.tf
+++ b/tf/kubernetes_main.tf
@@ -50,6 +50,7 @@ resource "azurerm_kubernetes_cluster" "this" {
     vnet_subnet_id               = var.virtual_networks == null || length(var.virtual_networks) == 0 ? null : azurerm_subnet.this[2].id
     orchestrator_version         = var.kubernetes_clusters[count.index].kubernetes_version == null || var.kubernetes_clusters[count.index].kubernetes_version == "" ? null : var.kubernetes_clusters[count.index].kubernetes_version
     only_critical_addons_enabled = coalesce(var.kubernetes_clusters[count.index].default_node_pool.only_critical_addons_enabled, false)
+    os_sku                       = var.kubernetes_clusters[count.index].default_node_pool.os_sku == null || var.kubernetes_clusters[count.index].default_node_pool.os_sku == "" ? "Ubuntu" : var.kubernetes_clusters[count.index].default_node_pool.os_sku
   }
 
   network_profile {

--- a/tf/kubernetes_variables.tf
+++ b/tf/kubernetes_variables.tf
@@ -25,6 +25,7 @@ variable "kubernetes_clusters" {
       max_count                    = number
       vm_size                      = string
       only_critical_addons_enabled = bool
+      os_sku                       = string
     })
   }))
 }


### PR DESCRIPTION
This enables provisioning clusters on Azure Linux or Ubuntu, but does not add support for Windows nodes, as the system node pool can't run on Windows.