### PR TITLE
Workload identity

### DIFF
--- a/internal/entity/lab.go
+++ b/internal/entity/lab.go
@@ -33,14 +33,16 @@ type TfvarAddonsType struct {
 }
 
 type TfvarKubernetesClusterType struct {
-	KubernetesVersion     string                   `json:"kubernetesVersion"`
-	NetworkPlugin         string                   `json:"networkPlugin"`
-	NetworkPolicy         string                   `json:"networkPolicy"`
-	NetworkPluginMode     string                   `json:"networkPluginMode"`
-	OutboundType          string                   `json:"outboundType"`
-	PrivateClusterEnabled string                   `json:"privateClusterEnabled"`
-	Addons                TfvarAddonsType          `json:"addons"`
-	DefaultNodePool       TfvarDefaultNodePoolType `json:"defaultNodePool"`
+	KubernetesVersion       string                   `json:"kubernetesVersion"`
+	NetworkPlugin           string                   `json:"networkPlugin"`
+	NetworkPolicy           string                   `json:"networkPolicy"`
+	NetworkPluginMode       string                   `json:"networkPluginMode"`
+	OutboundType            string                   `json:"outboundType"`
+	PrivateClusterEnabled   string                   `json:"privateClusterEnabled"`
+	OidcIssuerEnabled       bool                     `json:"oidcIssuerEnabled"`
+	WorkloadIdentityEnabled bool                     `json:"workloadIdentityEnabled"`
+	Addons                  TfvarAddonsType          `json:"addons"`
+	DefaultNodePool         TfvarDefaultNodePoolType `json:"defaultNodePool"`
 }
 
 type TfvarVirtualNetworkType struct {

--- a/internal/service/lab.go
+++ b/internal/service/lab.go
@@ -196,14 +196,16 @@ func (l *labService) HelperDefaultLab() (entity.LabType, error) {
 
 	var defaultKubernetesClusters = []entity.TfvarKubernetesClusterType{
 		{
-			KubernetesVersion:     l.kVersionService.GetDefaultVersion(),
-			NetworkPlugin:         "kubenet",
-			NetworkPolicy:         "null",
-			NetworkPluginMode:     "null",
-			OutboundType:          "loadBalancer",
-			PrivateClusterEnabled: "false",
-			Addons:                defaultAddons,
-			DefaultNodePool:       defaultNodePool,
+			KubernetesVersion:       l.kVersionService.GetDefaultVersion(),
+			NetworkPlugin:           "kubenet",
+			NetworkPolicy:           "null",
+			NetworkPluginMode:       "null",
+			OutboundType:            "loadBalancer",
+			PrivateClusterEnabled:   "false",
+			OidcIssuerEnabled:       false,
+			WorkloadIdentityEnabled: false,
+			Addons:                  defaultAddons,
+			DefaultNodePool:         defaultNodePool,
 		},
 	}
 

--- a/tf/kubernetes_main.tf
+++ b/tf/kubernetes_main.tf
@@ -39,6 +39,8 @@ resource "azurerm_kubernetes_cluster" "this" {
   dns_prefix              = "aks"
   private_cluster_enabled = var.kubernetes_clusters[count.index].private_cluster_enabled
   kubernetes_version      = var.kubernetes_clusters[count.index].kubernetes_version == null || var.kubernetes_clusters[count.index].kubernetes_version == "" ? null : var.kubernetes_clusters[count.index].kubernetes_version
+  oidc_issuer_enabled     = var.kubernetes_clusters[count.index].workload_identity_enabled == null || var.kubernetes_clusters[count.index].workload_identity_enabled == "" ? null : var.kubernetes_clusters[count.index].workload_identity_enabled
+  workload_identity_enabled = var.kubernetes_clusters[count.index].workload_identity_enabled == null || var.kubernetes_clusters[count.index].workload_identity_enabled == "" ? null : var.kubernetes_clusters[count.index].workload_identity_enabled
 
   default_node_pool {
     name                         = "default"

--- a/tf/kubernetes_output.tf
+++ b/tf/kubernetes_output.tf
@@ -41,3 +41,8 @@ output "kubelet_msi_principal_id" {
   value       = length(var.kubernetes_clusters) == 0 ? "" : azurerm_user_assigned_identity.kubelet_identity[0].principal_id
   description = "ID of User assigned Identity for kubelet"
 }
+
+output "cluster_oidc_issuer_url" {
+  value       = length(var.kubernetes_clusters) == 0 ? "" : azurerm_kubernetes_cluster.this[0].oidc_issuer_url
+  description = "The OIDC Issuer URL associated with this AKS Cluster"
+}

--- a/tf/kubernetes_variables.tf
+++ b/tf/kubernetes_variables.tf
@@ -1,12 +1,14 @@
 variable "kubernetes_clusters" {
   description = "AKS Cluster Object"
   type = list(object({
-    kubernetes_version      = string
-    network_plugin          = string
-    network_policy          = string
-    network_plugin_mode     = string
-    outbound_type           = string
-    private_cluster_enabled = bool
+    kubernetes_version        = string
+    network_plugin            = string
+    network_policy            = string
+    network_plugin_mode       = string
+    outbound_type             = string
+    oidc_issuer_enabled       = bool
+    workload_identity_enabled = bool
+    private_cluster_enabled   = bool
     addons = object({
       app_gateway              = bool
       microsoft_defender       = bool


### PR DESCRIPTION
Adding workload identity support for ACTLabs.

Two attributes in Terraform need to be enabled at the same time (`workload_identity_enabled` and `oidc_issuer_enabled`) so this adds both elements to `TfvarKuberentesClusterType` and sets them to false by default.

I don't know if it's worth separating OIDC issuer and workload identity, since OIDC issuer could be used outside of WI for third-party OIDC providers.