### PR TITLE
feat: Filter Kubernetes versions by official support

### DIFF
--- a/internal/service/kversion.go
+++ b/internal/service/kversion.go
@@ -46,7 +46,19 @@ func (k *kVersionService) GetOrchestrator() (entity.KubernetesVersions, error) {
 		return kubernetesVersions, err
 	}
 
-	return kubernetesVersions, nil
+	// Filter Kubernetes versions
+	filteredVersions := entity.KubernetesVersions{}
+	for _, version := range kubernetesVersions.Values {
+		for _, capability := range version.Capabilities.SupportPlan {
+			if capability == "KubernetesOfficial" {
+				slog.Info("Adding version " + version.Version)
+				filteredVersions.Values = append(filteredVersions.Values, version)
+				break
+			}
+		}
+	}
+
+	return filteredVersions, nil
 }
 
 func (k *kVersionService) GetMostRecentVersion() string {


### PR DESCRIPTION
This commit modifies the `GetOrchestrator` function in `kversion.go` to filter the Kubernetes versions based on their support plan. Only versions with the capability "KubernetesOfficial" are included in the `filteredVersions` slice. This change ensures that only officially supported Kubernetes versions are returned.

Note: This commit message follows the established convention of using a prefix to indicate the type of change (feat for feature, chore for maintenance tasks).