### PR TITLE
Support Access Key Policy Change

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -64,11 +64,11 @@ func NewAuth(appConfig *config.Config) *Auth {
 func AzureCLILoginByMSI(username string) {
 	out, err := exec.Command("bash", "-c", "az login --identity --username "+username).Output()
 	if err != nil {
-		slog.Error("not able to login using msi", err)
+		slog.Error("not able to login using msi "+username, err)
 		os.Exit(1)
 	}
 
-	slog.Info("az login --identity output: " + string(out))
+	slog.Info("az login --identity --username " + username + " output: " + string(out))
 }
 
 // login using service principal
@@ -88,6 +88,14 @@ func AzureCLILoginByServicePrincipal(username string, password string, subscript
 	}
 
 	slog.Info("az account set --subscription output: " + string(out))
+
+	out, err = exec.Command("bash", "-c", "az account show").Output()
+	if err != nil {
+		slog.Error("not able to show account", err)
+		os.Exit(1)
+	}
+
+	slog.Info("az account show output: " + string(out))
 }
 
 func (a *Auth) GetARMAccessToken() (string, error) {

--- a/internal/entity/lab.go
+++ b/internal/entity/lab.go
@@ -100,24 +100,26 @@ type EnumerationResults struct {
 }
 
 type LabType struct {
-	Id               string          `json:"id"`
-	Name             string          `json:"name"`
-	Description      string          `json:"description"`
-	Tags             []string        `json:"tags"`
-	Template         TfvarConfigType `json:"template"`
-	ExtendScript     string          `json:"extendScript"`
-	Message          string          `json:"message"`
-	Category         string          `json:"category"`
-	Type             string          `json:"type"`
-	CreatedBy        string          `json:"createdBy"`
-	CreatedOn        string          `json:"createdOn"`
-	UpdatedBy        string          `json:"updatedBy"`
-	UpdatedOn        string          `json:"updatedOn"`
-	Owners           []string        `json:"owners"`
-	Editors          []string        `json:"editors"`
-	Viewers          []string        `json:"viewers"`
-	VersionId        string          `json:"versionId"`
-	IsCurrentVersion bool            `json:"isCurrentVersion"`
+	Id                       string          `json:"id"`
+	Name                     string          `json:"name"`
+	Description              string          `json:"description"`
+	Tags                     []string        `json:"tags"`
+	Template                 TfvarConfigType `json:"template"`
+	ExtendScript             string          `json:"extendScript"`
+	Message                  string          `json:"message"`
+	Category                 string          `json:"category"`
+	Type                     string          `json:"type"`
+	CreatedBy                string          `json:"createdBy"`
+	CreatedOn                string          `json:"createdOn"`
+	UpdatedBy                string          `json:"updatedBy"`
+	UpdatedOn                string          `json:"updatedOn"`
+	Owners                   []string        `json:"owners"`
+	Editors                  []string        `json:"editors"`
+	Viewers                  []string        `json:"viewers"`
+	RbacEnforcedProtectedLab bool            `json:"rbacEnforcedProtectedLab"`
+	VersionId                string          `json:"versionId"`
+	IsCurrentVersion         bool            `json:"isCurrentVersion"`
+	SupportingDocumentId     string          `json:"supportingDocumentId"`
 }
 
 type BlobType struct {

--- a/scripts/helper.sh
+++ b/scripts/helper.sh
@@ -89,6 +89,7 @@ function tf_init() {
 
   # Change to TF Directory
   changeToTerraformDirectory
+  enableSharedKeyAccess
 
   # Initialize terraform only if not.
   if [[ ! -f .terraform/terraform.tfstate ]] || [[ ! -f .terraform.lock.hcl ]]; then
@@ -140,6 +141,14 @@ function init() {
   get_aks_credentials
   # changeToTerraformDirectory
   get_kubectl
+}
+
+function enableSharedKeyAccess() {
+  # Enable shared key access to storage account if not already enabled
+  sharedKeyAccess=$(az storage account show --name "$storage_account_name" -g "$resource_group_name" --query "allowSharedKeyAccess" --output tsv)
+  if [[ ${sharedKeyAccess} == "false" ]]; then
+    az storage account update --name "$storage_account_name" -g "$resource_group_name" --allow-shared-key-access true
+  fi
 }
 
 # Adding sources

--- a/scripts/workspaces.sh
+++ b/scripts/workspaces.sh
@@ -6,56 +6,46 @@
 OPTION=$1
 WORKSPACE=$2
 
-function init() {
-    # Initialize terraform only if not.
-    if [[ ! -f .terraform/terraform.tfstate ]] || [[ ! -f .terraform.lock.hcl ]]; then
-        terraform init \
-            -migrate-state \
-            -backend-config="resource_group_name=$resource_group_name" \
-            -backend-config="storage_account_name=$storage_account_name" \
-            -backend-config="container_name=$container_name" \
-            -backend-config="key=$tf_state_file_name" >/dev/null 2>&1
-    fi
-}
+source $ROOT_DIR/scripts/helper.sh
 
 function listWorkspaces() {
 
-    workspaces=$(terraform workspace list)
-    IFS=$'\n'
-    list=""
-    for line in $workspaces; do
-        #line=${line/*\* /} # Removes the * from selected workspace.
-        #line=${line/*\ /} # Removes leading spaces.
-        line=$(echo ${line} | tr -s ' ')
-        if [[ "${list}" == "" ]]; then
-            list="${line}"
-        else
-            list="${list},${line}"
-        fi
-    done
-    printf ${list}
+  workspaces=$(terraform workspace list)
+  IFS=$'\n'
+  list=""
+  for line in $workspaces; do
+    #line=${line/*\* /} # Removes the * from selected workspace.
+    #line=${line/*\ /} # Removes leading spaces.
+    line=$(echo ${line} | tr -s ' ')
+    if [[ "${list}" == "" ]]; then
+      list="${line}"
+    else
+      list="${list},${line}"
+    fi
+  done
+  printf ${list}
 }
 
 function selectWorkspace() {
-    terraform workspace select $WORKSPACE
+  terraform workspace select $WORKSPACE
 }
 
 function createWorkspace() {
-    terraform workspace create $WORKSPACE
+  terraform workspace create $WORKSPACE
 }
 
 # Script starts here.
 cd ${ROOT_DIR}/tf
 
 if [[ "$ARM_SUBSCRIPTION_ID" == "" ]]; then
-    export ARM_SUBSCRIPTION_ID=$(az account show --output json --only-show-error | jq -r .id)
+  export ARM_SUBSCRIPTION_ID=$(az account show --output json --only-show-error | jq -r .id)
 fi
 
-init
+tf_init
 
 if [[ "$OPTION" == "list" ]]; then
-    listWorkspaces
-    exit 0
+  listWorkspaces
+  exit 0
 fi
 
 terraform workspace $OPTION $WORKSPACE

--- a/scripts/workspaces.sh
+++ b/scripts/workspaces.sh
@@ -6,7 +6,27 @@
 OPTION=$1
 WORKSPACE=$2
 
-source $ROOT_DIR/scripts/helper.sh
+# We are not using function from helper.sh cause this function needs to be quiet. i.e. no output.
+function enableSharedKeyAccess() {
+  # Enable shared key access to storage account if not already enabled
+  sharedKeyAccess=$(az storage account show --name "$storage_account_name" -g "$resource_group_name" --query "allowSharedKeyAccess" --output tsv 2>/dev/null)
+  if [[ ${sharedKeyAccess} == "false" ]]; then
+    az storage account update --name "$storage_account_name" -g "$resource_group_name" --allow-shared-key-access true >/dev/null 2>&1
+  fi
+}
+
+# We are not using function from helper.sh cause this function needs to be quiet. i.e. no output.
+function init() {
+  # Initialize terraform only if not.
+  if [[ ! -f .terraform/terraform.tfstate ]] || [[ ! -f .terraform.lock.hcl ]]; then
+    terraform init \
+      -migrate-state \
+      -backend-config="resource_group_name=$resource_group_name" \
+      -backend-config="storage_account_name=$storage_account_name" \
+      -backend-config="container_name=$container_name" \
+      -backend-config="key=$tf_state_file_name" >/dev/null 2>&1
+  fi
+}
 
 function listWorkspaces() {
 
@@ -41,7 +61,8 @@ if [[ "$ARM_SUBSCRIPTION_ID" == "" ]]; then
   export ARM_SUBSCRIPTION_ID=$(az account show --output json --only-show-error | jq -r .id)
 fi
 
-tf_init
+enableSharedKeyAccess
+init
 
 if [[ "$OPTION" == "list" ]]; then
   listWorkspaces


### PR DESCRIPTION
This pull request includes several changes aimed at improving logging, enhancing Azure Blob Storage access, and adding new fields to the `LabType` struct. The most important changes include enhancing error logging with additional context, replacing shared key credentials with Azure Active Directory (AAD) credentials for Blob Storage access, and adding new fields to the `LabType` struct.

### Logging Improvements:
* [`internal/auth/auth.go`](diffhunk://#diff-69673fb1085db41e623b0fb8adc07c7396117ca9c37992e72dd1d7b8f2665f7fL67-R71): Enhanced error logging by including the `username` in the error messages for `AzureCLILoginByMSI` and added logging for `az account show` in `AzureCLILoginByServicePrincipal`. [[1]](diffhunk://#diff-69673fb1085db41e623b0fb8adc07c7396117ca9c37992e72dd1d7b8f2665f7fL67-R71) [[2]](diffhunk://#diff-69673fb1085db41e623b0fb8adc07c7396117ca9c37992e72dd1d7b8f2665f7fR91-R98)

### Azure Blob Storage Access:
* [`internal/repository/preference.go`](diffhunk://#diff-4a9a37b43eba761a555d3aba9dc141519e2db15528b11f99ddde0ac8dd1fd01eL42-L92): Replaced the use of shared key credentials with AAD credentials for creating Blob Service Clients in `GetPreferenceFromBlob` and `PutPreferenceInBlob`. [[1]](diffhunk://#diff-4a9a37b43eba761a555d3aba9dc141519e2db15528b11f99ddde0ac8dd1fd01eL42-L92) [[2]](diffhunk://#diff-4a9a37b43eba761a555d3aba9dc141519e2db15528b11f99ddde0ac8dd1fd01eL102-R98)

### Struct Enhancements:
* [`internal/entity/lab.go`](diffhunk://#diff-d5633b476a884b495935badf2ed1541228f738e3083bd4538801bda63c0aa0d4R119-R122): Added `RbacEnforcedProtectedLab` and `SupportingDocumentId` fields to the `LabType` struct.

### Shell Script Enhancements:
* [`scripts/helper.sh`](diffhunk://#diff-149defba3b7948dc5d8da384af59e4350328c87429dddb209b4f2a27fa6cfec5R92): Added a new function `enableSharedKeyAccess` to enable shared key access for storage accounts if not already enabled. [[1]](diffhunk://#diff-149defba3b7948dc5d8da384af59e4350328c87429dddb209b4f2a27fa6cfec5R92) [[2]](diffhunk://#diff-149defba3b7948dc5d8da384af59e4350328c87429dddb209b4f2a27fa6cfec5R146-R153)
* [`scripts/workspaces.sh`](diffhunk://#diff-2d61bee71efd1f5f7a3077ca713029438da58b5be5b48691d07664578cecc971R9-R18): Added the `enableSharedKeyAccess` function to ensure shared key access is enabled quietly before initializing Terraform. [[1]](diffhunk://#diff-2d61bee71efd1f5f7a3077ca713029438da58b5be5b48691d07664578cecc971R9-R18) [[2]](diffhunk://#diff-2d61bee71efd1f5f7a3077ca713029438da58b5be5b48691d07664578cecc971R64)