### PR TITLE
Clear Cached Kubernetes Versions on Preference Changes

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -52,10 +52,10 @@ fi
 
 rm one-click-aks-server
 
-docker tag repro:${TAG} actlab.azurecr.io/repro:${TAG}
+docker tag repro:${TAG} actlabs.azurecr.io/repro:${TAG}
 
-az acr login --name actlab --subscription ACT-CSS-Readiness
-docker push actlab.azurecr.io/repro:${TAG}
+az acr login --name actlabs --subscription ACT-CSS-Readiness-NPRD
+docker push actlabs.azurecr.io/repro:${TAG}
 
 docker tag repro:${TAG} ashishvermapu/repro:${TAG}
 docker push ashishvermapu/repro:${TAG}

--- a/internal/entity/preference.go
+++ b/internal/entity/preference.go
@@ -15,4 +15,6 @@ type PreferenceRepository interface {
 	PutPreferenceInBlob(val string, storageAccountName string) error
 	GetPreferenceFromRedis() (string, error)
 	PutPreferenceInRedis(val string) error
+	DeletePreferenceFromRedis() error
+	DeleteKubernetesVersionsFromRedis() error
 }

--- a/internal/repository/preference.go
+++ b/internal/repository/preference.go
@@ -111,3 +111,13 @@ func (p *preferenceRepository) PutPreferenceInRedis(val string) error {
 	rdb := newPreferenceRedisClient()
 	return rdb.Set(preferenceCtx, "preference", val, 0).Err()
 }
+
+func (p *preferenceRepository) DeletePreferenceFromRedis() error {
+	rdb := newPreferenceRedisClient()
+	return rdb.Del(preferenceCtx, "preference").Err()
+}
+
+func (p *preferenceRepository) DeleteKubernetesVersionsFromRedis() error {
+	rdb := newPreferenceRedisClient()
+	return rdb.Del(preferenceCtx, "kubernetesVersions").Err()
+}

--- a/internal/service/preference.go
+++ b/internal/service/preference.go
@@ -86,6 +86,17 @@ func (p *preferenceService) SetPreference(preference entity.Preference) error {
 		return err
 	}
 
+	// Cleanup Cache
+	if err := p.preferenceRepository.DeletePreferenceFromRedis(); err != nil {
+		slog.Error("not able to delete preference from redis", err)
+		return err
+	}
+
+	if err := p.preferenceRepository.DeleteKubernetesVersionsFromRedis(); err != nil {
+		slog.Error("not able to delete kubernetes versions from redis", err)
+		return err
+	}
+
 	if err := p.preferenceRepository.PutPreferenceInRedis(string(out)); err != nil {
 		slog.Error("not able to put preference in redis", err)
 		return err

--- a/scripts/terraform_debug.sh
+++ b/scripts/terraform_debug.sh
@@ -9,22 +9,21 @@ export ROOT_DIR=$(pwd)
 source $ROOT_DIR/scripts/helper.sh
 
 # change to 'trace' if thats what you want. But in most cases 'debug' is good enough.
-export TF_LOG=trace
+export TF_LOG=debug
 
 # Following variables are used by terraform. Change them as you need.
 # You will get these from the output on the UI.
 # just run terraform plan and copy the environment variables which start with TF_VAR
 # modify them to be on liners and paste them here.
-export TF_VAR_network_security_groups='[{}]'
-export TF_VAR_container_registries='[{}]'
-export TF_VAR_subnets='[{"name": "AzureFirewallSubnet","address_prefixes": [  "10.1.1.0/24"]},{"name": "JumpServerSubnet","address_prefixes": [  "10.1.2.0/24"]},{"name": "KubernetesSubnet","address_prefixes": [  "10.1.3.0/24"]},{"name": "AppGatewaySubnet","address_prefixes": [  "10.1.4.0/24"]},{"name": "AROMasterSubnet","address_prefixes": [  "10.1.5.0/24"]},{"name": "AROWorkerSubnet","address_prefixes": [  "10.1.6.0/24"]},{"name": "KubernetesVirtualNodeSubnet","address_prefixes": [  "10.1.7.0/24"]}]'
-export TF_VAR_firewalls='[{"sku_name": "AZFW_VNet","sku_tier": "Standard"}]'
-export TF_VAR_app_gateways='[]'
-export TF_VAR_jumpservers='[{"admin_password": "Password1234!","admin_username": "aksadmin"}]'
-export TF_VAR_virtual_networks='[{"address_space": [  "10.1.0.0/16"]}]'
 export TF_VAR_resource_group='{"location": "East US"}'
-export TF_VAR_kubernetes_clusters='[{"kubernetes_version": "1.27.3","network_plugin": "azure","network_policy": "calico","network_plugin_mode": "null","outbound_type": "userDefinedRouting","private_cluster_enabled": "true","addons": {  "app_gateway": true,  "microsoft_defender": true,  "virtual_node": true,  "http_application_routing": true,  "service_mesh": {    "enabled": true,    "mode": "Istio",    "internal_ingress_gateway_enabled": true,    "external_ingress_gateway_enabled": false  }},"default_node_pool": {"enable_auto_scaling": true,"min_count": 1,"max_count": 1}}]'
-
+export TF_VAR_network_security_groups='[]'
+export TF_VAR_container_registries='[]'
+export TF_VAR_subnets='[]'
+export TF_VAR_firewalls='[]'
+export TF_VAR_app_gateways='[]'
+export TF_VAR_jumpservers='[]'
+export TF_VAR_virtual_networks='[]'
+export TF_VAR_kubernetes_clusters='[]'
 # Following variables are used by the helper script. No need to change them.
 export terraform_directory="tf"
 export root_directory=$(pwd)
@@ -35,69 +34,78 @@ export tf_state_file_name="terraform.tfstate"
 # add the storage account name here. you will find that on UI in settings.
 export storage_account_name="iv3p7230nbdw"
 
+# Update tf/provers.tf to remove backend configuration.
+sed -i '/backend "azurerm" {}/d' $root_directory/$terraform_directory/providers.tf
+
+# Remove existing terraform init
+rm -rf $root_directory/$terraform_directory/.terraform*
+
+# Terraform Init - Sourced from helper script.
+$root_directory/scripts/terraform.sh init
+
 function plan() {
-    log "Planning"
-    terraform plan
+  log "Planning"
+  terraform plan
 }
 
 function apply() {
-    log "Applying"
-    terraform apply -auto-approve
-    if [ $? -ne 0 ]; then
-        err "Terraform Apply Failed"
-        exit 1
-    fi
+  log "Applying"
+  terraform apply -auto-approve
+  if [ $? -ne 0 ]; then
+    err "Terraform Apply Failed"
+    exit 1
+  fi
 }
 
 function destroy() {
-    log "Destroying"
-    terraform destroy -auto-approve
-    if [ $? -ne 0 ]; then
-        err "Terraform Destroy Failed"
-        exit 1
-    fi
+  log "Destroying"
+  terraform destroy -auto-approve
+  if [ $? -ne 0 ]; then
+    err "Terraform Destroy Failed"
+    exit 1
+  fi
 }
 
 function list() {
-    log "Listing"
-    terraform state list
+  log "Listing"
+  terraform state list
 }
 
 function getSecertsFromKeyVault() {
-    # Following two are already availabe.
-    export ARM_SUBSCRIPTION_ID=$(az account show --output json | jq -r .id)
-    export ARM_TENANT_ID=$(az account show --output json | jq -r .tenantId)
+  # Following two are already availabe.
+  export ARM_SUBSCRIPTION_ID=$(az account show --output json | jq -r .id)
+  export ARM_TENANT_ID=$(az account show --output json | jq -r .tenantId)
 
-    # Resource group need not be changed.
-    RESOURCE_GROUP_NAME="repro-project"
+  # Resource group need not be changed.
+  RESOURCE_GROUP_NAME="repro-project"
 
-    log "Pulling secrets from keyvault. This will take just a few moments."
+  log "Pulling secrets from keyvault. This will take just a few moments."
 
-    # Get the name of the Key Vault in the resource group
-    KEY_VAULT_NAME=$(az keyvault list --resource-group "${RESOURCE_GROUP_NAME}" --query "[].name" -o tsv)
+  # Get the name of the Key Vault in the resource group
+  KEY_VAULT_NAME=$(az keyvault list --resource-group "${RESOURCE_GROUP_NAME}" --query "[].name" -o tsv)
+  if [ $? -ne 0 ]; then
+    err "Failed to get key vault name in resource group ${RESOURCE_GROUP_NAME}"
+    return 1
+  fi
+  # Get a list of all secrets in the Key Vault
+  SECRET_NAMES=$(az keyvault secret list --vault-name "${KEY_VAULT_NAME}" --query "[].name" -o tsv)
+  if [ $? -ne 0 ]; then
+    err "Failed to get secrets from key vault ${KEY_VAULT_NAME}"
+    return 1
+  fi
+
+  # Loop through the list of secrets and set them as environment variables
+  for SECRET_NAME in $SECRET_NAMES; do
+    ENV_VAR_NAME=$(echo "$SECRET_NAME" | tr '[:lower:]' '[:upper:]' | tr '-' '_')
+    SECRET_VALUE=$(az keyvault secret show --vault-name "${KEY_VAULT_NAME}" --name "${SECRET_NAME}" --query "value" -o tsv)
     if [ $? -ne 0 ]; then
-        err "Failed to get key vault name in resource group ${RESOURCE_GROUP_NAME}"
-        return 1
+      err "Failed to get secret ${SECRET_NAME} from key vault ${KEY_VAULT_NAME}"
+      return 1
     fi
-    # Get a list of all secrets in the Key Vault
-    SECRET_NAMES=$(az keyvault secret list --vault-name "${KEY_VAULT_NAME}" --query "[].name" -o tsv)
-    if [ $? -ne 0 ]; then
-        err "Failed to get secrets from key vault ${KEY_VAULT_NAME}"
-        return 1
-    fi
+    export "${ENV_VAR_NAME}"="${SECRET_VALUE}"
+  done
 
-    # Loop through the list of secrets and set them as environment variables
-    for SECRET_NAME in $SECRET_NAMES; do
-        ENV_VAR_NAME=$(echo "$SECRET_NAME" | tr '[:lower:]' '[:upper:]' | tr '-' '_')
-        SECRET_VALUE=$(az keyvault secret show --vault-name "${KEY_VAULT_NAME}" --name "${SECRET_NAME}" --query "value" -o tsv)
-        if [ $? -ne 0 ]; then
-            err "Failed to get secret ${SECRET_NAME} from key vault ${KEY_VAULT_NAME}"
-            return 1
-        fi
-        export "${ENV_VAR_NAME}"="${SECRET_VALUE}"
-    done
-
-    return 0
+  return 0
 }
 
 ##
@@ -113,7 +121,7 @@ function getSecertsFromKeyVault() {
 # fi
 
 if [[ "$ARM_SUBSCRIPTION_ID" == "" ]]; then
-    export ARM_SUBSCRIPTION_ID=$(az account show --output json | jq -r .id)
+  export ARM_SUBSCRIPTION_ID=$(az account show --output json | jq -r .id)
 fi
 
 cd $root_directory/$terraform_directory
@@ -123,18 +131,18 @@ echo ""
 
 # Delete existing if init
 if [[ "$action" == "init" ]]; then
-    rm -rf .terraform*
+  rm -rf .terraform*
 fi
 
 # Terraform Init - Sourced from helper script.
 tf_init
 
 if [[ "$action" == "plan" ]]; then
-    plan
+  plan
 elif [[ "$action" == "apply" ]]; then
-    apply
+  apply
 elif [[ "$action" == "destroy" ]]; then
-    destroy
+  destroy
 fi
 
 ok "Terraform Action End"


### PR DESCRIPTION
This pull request includes several updates to the `build.sh`, `preference.go`, `preferenceRepository.go`, `preferenceService.go`, and `terraform_debug.sh` files. The most important changes involve updating Docker registry configurations, adding new methods for Redis cache management, and modifying Terraform debug configurations.

### Docker Registry Configuration Updates:
* Updated Docker registry URLs and subscription names in `build.sh` to reflect the correct registry (`actlabs.azurecr.io`) and subscription (`ACT-CSS-Readiness-NPRD`).

### Redis Cache Management Enhancements:
* Added `DeletePreferenceFromRedis` and `DeleteKubernetesVersionsFromRedis` methods to the `PreferenceRepository` interface in `internal/entity/preference.go`.
* Implemented the `DeletePreferenceFromRedis` and `DeleteKubernetesVersionsFromRedis` methods in the `preferenceRepository` struct in `internal/repository/preference.go`.
* Updated the `SetPreference` method in `internal/service/preference.go` to clean up the Redis cache by deleting old preferences and Kubernetes versions before setting new preferences.

### Terraform Debug Configuration Modifications:
* Changed the `TF_LOG` environment variable from `trace` to `debug` and updated several `TF_VAR_*` variables to empty arrays in `scripts/terraform_debug.sh`.
* Added commands to remove backend configuration from `providers.tf`, clean up existing Terraform initialization, and reinitialize Terraform in `scripts/terraform_debug.sh`.